### PR TITLE
Logger: switch to nanoseconds

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,12 +1,10 @@
 COMPOSE_PROJECT_NAME=matrixbot-go-common-lib
 
-LOG_LEVEL=1
 ES_PROTO=http
 ES_HOST=localhost
 ES_PORT=9200
 ES_INDEX=logs
 
-#export LOG_LEVEL=1
 #export ES_PROTO=http
 #export ES_HOST=localhost
 #export ES_PORT=9200

--- a/pkg/zes/config.go
+++ b/pkg/zes/config.go
@@ -18,6 +18,7 @@ func newConsoleConfig() zapcore.EncoderConfig {
 	cfg.MessageKey = messageKey
 	cfg.StacktraceKey = stacktraceKey
 	cfg.LevelKey = levelTextKey
+	cfg.EncodeTime = zapcore.RFC3339NanoTimeEncoder
 
 	return cfg
 }
@@ -28,7 +29,7 @@ func newJsonConfig() zapcore.EncoderConfig {
 	cfg.MessageKey = messageKey
 	cfg.StacktraceKey = stacktraceKey
 	cfg.LevelKey = levelTextKey
-	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	cfg.EncodeTime = zapcore.RFC3339NanoTimeEncoder
 
 	return cfg
 }


### PR DESCRIPTION
В GUI кибаны локально так и не смог настроить что бы выводилиь НАНО  
обрезается до мили, и 00000 добавляет  

но  curl -H 'Content-Type: application/json' -X GET http://localhost:9200/logs/_search    дает верный результат, в наносекундах, т.о. в ES все верно попадает и хранится.